### PR TITLE
bug fix: load target_sr from input yaml to data config

### DIFF
--- a/deepfense/cli/commands/test.py
+++ b/deepfense/cli/commands/test.py
@@ -219,6 +219,8 @@ def test(config, checkpoint):
             test_cfg["label_map"] = OmegaConf.to_container(cfg.data.label_map, resolve=True)
         if "sampling_rate" in cfg.data:
             test_cfg["sampling_rate"] = cfg.data.sampling_rate
+        if "target_sr" in cfg.data:
+            test_cfg["target_sr"] = cfg.data.target_sr
     except Exception:
         logger.error("Could not configure test dataset.")
         return

--- a/deepfense/cli/commands/train.py
+++ b/deepfense/cli/commands/train.py
@@ -124,6 +124,12 @@ def train(config, resume):
         if "test" in cfg.data:
             cfg.data.test.sampling_rate = cfg.data.sampling_rate
 
+    if "target_sr" in cfg.data:
+        cfg.data.train.target_sr = cfg.data.target_sr
+        cfg.data.val.target_sr = cfg.data.target_sr
+        if "test" in cfg.data:
+            cfg.data.test.target_sr = cfg.data.target_sr
+
     train_loader = build_dataloader(OmegaConf.to_container(cfg.data.train, resolve=True))
     val_loader = build_dataloader(OmegaConf.to_container(cfg.data.val, resolve=True))
 


### PR DESCRIPTION
Q: Do we still need the `sample_rate` in `train.py` and `test.py`?
Also, in rawboost, the sample rate is hard coded.