### PR TITLE
feat: support trimming leading and tailing silence

### DIFF
--- a/deepfense/data/transforms/augmentations.py
+++ b/deepfense/data/transforms/augmentations.py
@@ -389,6 +389,35 @@ class DropChunk:
         return dropped_audio
 
 
+@register_transform("trim_silence")
+class TrimSilence:
+    """Trim leading and trailing silence from audio using librosa.effects.trim."""
+
+    def __init__(
+        self,
+        noise_ratio: float = 1.0,
+        top_db: float = 30.0,
+        frame_length: int = 1024,
+        hop_length: int = 256,
+    ):
+        self.noise_ratio = noise_ratio
+        self.top_db = top_db
+        self.frame_length = frame_length
+        self.hop_length = hop_length
+
+    def __call__(self, x: np.ndarray) -> np.ndarray:
+        if np.random.random() > self.noise_ratio:
+            return x
+
+        trimmed, _ = librosa.effects.trim(
+            y=x,
+            top_db=self.top_db,
+            frame_length=self.frame_length,
+            hop_length=self.hop_length,
+        )
+
+        return trimmed
+
 @register_transform("do_clip")
 class DoClip:
     def __init__(self, 


### PR DESCRIPTION
Support trimming the leading and tailing silence.

Test
- The feature has been tested locally, the silent parts are correctly removed
- The whole pipeline including trim_silence as an augmentation has been tested locally. The debug.yaml is based on [ASV19_Wav2Vec2_MLP_NoAug_Seed2](https://huggingface.co/DeepFense/ASV19_Wav2Vec2_MLP_NoAug_Seed2/blob/main/config.yaml). The main difference was the data parquets were replaced with emofake's to test it faster. 